### PR TITLE
[🚑FIX] 커리큘럼 데이터 순서를 수정한다

### DIFF
--- a/components/Graduate/TapWrapper.tsx
+++ b/components/Graduate/TapWrapper.tsx
@@ -36,13 +36,13 @@ export default function TapWrapper({
               />
             </Tab.Panel>
             <Tab.Panel>
-              <SemesterWrapper spring={junior?.spring} fall={junior?.fall} />
-            </Tab.Panel>
-            <Tab.Panel>
               <SemesterWrapper
                 spring={sophomore?.spring}
                 fall={sophomore?.fall}
               />
+            </Tab.Panel>
+            <Tab.Panel>
+              <SemesterWrapper spring={junior?.spring} fall={junior?.fall} />
             </Tab.Panel>
             <Tab.Panel>
               <SemesterWrapper spring={senior?.spring} fall={senior?.fall} />

--- a/components/Graduate/content/curriculum.tsx
+++ b/components/Graduate/content/curriculum.tsx
@@ -9,8 +9,8 @@ const CurricularmPage = ({ Curriculum }: any) => {
         key={el.id}
         major={el.major}
         freshmen={el.freshmen}
-        junior={el.junior}
         sophomore={el.sophomore}
+        junior={el.junior}
         senior={el.senior}
       />
     );


### PR DESCRIPTION
## 구현 목록
Issue: #75 

- [ ] 커리큘럼에서 2, 3학년이 변경되어있던 에러를 수정했다.

## 시연 

### 정상적으로 조직심리학 등의 과목이 3학년으로 나온다
![image](https://user-images.githubusercontent.com/100553086/216922790-655a1111-7d28-4ead-afca-4308c5780578.png)

![image](https://user-images.githubusercontent.com/100553086/216922827-3eb8704a-6fa8-4bc4-bcf1-2df33045646e.png)
