### PR TITLE
[💄DESIGN] 모든 페이지에 반응형 적용한다

### DIFF
--- a/components/Home/SurvivalWrapper.tsx
+++ b/components/Home/SurvivalWrapper.tsx
@@ -13,6 +13,7 @@ export default function SurvivalWrapper({
   return (
     <>
       {/* 기본적으로 1/2 768px부터 1/3 1024부터 1/4*/}
+
       <div className="w-1/2 md:w-1/3 lg:w-1/4 p-2">
         <div className="h-[285px] dark:bg-slate-700 bg-gray-50 overflow-hidden relative">
           <Link href="/post/[id]" as={`/post/${tipId}`}>

--- a/pages/abroad/index.tsx
+++ b/pages/abroad/index.tsx
@@ -27,7 +27,7 @@ const Tabs = ({ Bridge, Exchange, Multi, Short, Global, Advice }: any) => {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <section className="text-gray-600 body-font">
+      <section className="text-gray-600 body-font max-w-[64rem] mx-auto">
         <div className="container px-5 mx-auto">
           <Tab
             tabs={[

--- a/pages/career/1.tsx
+++ b/pages/career/1.tsx
@@ -39,7 +39,7 @@ export default function Home({ AirForce }: any) {
           <link rel="icon" href="/favicon.ico" />
         </Head>
 
-        <section className="text-gray-600 body-font">
+        <section className="text-gray-600 body-font max-w-[64rem] mx-auto">
           {/* 프로필 */}
           <div className="container px-5 py-12 mx-auto flex flex-col">
             <section className="flexBox flex-col sm:flex-row">

--- a/pages/career/2.tsx
+++ b/pages/career/2.tsx
@@ -39,7 +39,7 @@ export default function Home({ Analyst }: any) {
           <link rel="icon" href="/favicon.ico" />
         </Head>
 
-        <section className="text-gray-600 body-font">
+        <section className="text-gray-600 body-font max-w-[64rem] mx-auto">
           {/* 프로필 */}
           <div className="container px-5 py-12  mx-auto flex flex-col">
             <section className="flexBox flex-col sm:flex-row">

--- a/pages/career/3.tsx
+++ b/pages/career/3.tsx
@@ -39,7 +39,7 @@ export default function Home({ WebProgrammer }: any) {
           <link rel="icon" href="/favicon.ico" />
         </Head>
 
-        <section className="text-gray-600 body-font">
+        <section className="text-gray-600 body-font max-w-[64rem] mx-auto">
           {/* 프로필 */}
           <div className="container px-5 py-12 mx-auto flex flex-col">
             <section className="flexBox flex-col sm:flex-row">

--- a/pages/career/index.tsx
+++ b/pages/career/index.tsx
@@ -26,11 +26,11 @@ export default function Home({ CareerInterview }: any) {
           <link rel="icon" href="/favicon.ico" />
         </Head>
 
-        <section className="text-gray-600 body-font bg-slate-200 dark:bg-slate-800 ">
+        <section className="text-gray-600 body-font max-w-[64rem] mx-auto">
           {/* 상단 배너 */}
           <Image
             src={'/images/취업.webp'}
-            className="lg:h-48 md:h-36 w-full object-cover object-center mb-4"
+            className="h-48 w-full object-cover object-center mb-4"
             alt="picture"
             width={1920}
             height={200}

--- a/pages/career/info.tsx
+++ b/pages/career/info.tsx
@@ -36,14 +36,14 @@ export default function Info() {
           <link rel="icon" href="/favicon.ico" />
         </Head>
 
-        <section className="text-gray-600 body-font ">
+        <section className="text-gray-600 body-font max-w-[64rem] mx-auto">
           <div className="container px-5 py-12 mx-auto flexBox flex-col">
             <StatusChart />
             <FirstJobChart />
           </div>
         </section>
 
-        <section>
+        <section className="max-w-[64rem] mx-auto">
           <div className="container px-5 py-12 mx-auto flex-col">
             <h1 className="text-4xl font-black text-left mb-4">평균초봉</h1>
             <AverageSalaryChart />

--- a/pages/graduate/index.tsx
+++ b/pages/graduate/index.tsx
@@ -27,7 +27,7 @@ const Tabs = ({ Curriculum, Prepare, Life, Major, Free }: any) => {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <section className="text-gray-600 body-font">
+      <section className="text-gray-600 body-font max-w-[64rem] mx-auto">
         <div className="container px-5 mx-auto">
           <Tab
             tabs={[

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -39,7 +39,10 @@ export default function Home({ data }: any) {
                 </p>
               </div>
             </div>
-            <div className="flex flex-wrap -m-4">{TipList}</div>
+            {/* 노트북 반응형 */}
+            <div className="flex flex-wrap max-w-[64rem] mx-auto -m-4">
+              {TipList}
+            </div>
           </div>
         </section>
       </Layout>

--- a/pages/introduce.tsx
+++ b/pages/introduce.tsx
@@ -26,7 +26,7 @@ export default function Introduce({ MemberData }: any) {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <section className="text-gray-600 body-font">
+      <section className="text-gray-600 body-font  max-w-[64rem] mx-auto">
         <div className="container px-5 py-12 mx-auto">
           <div className="flex-col flex-wrap w-full mb-20">
             <h2 className="mt-6 text-center text-5xl font-black tracking-tight text-gray-900">

--- a/pages/post/1.tsx
+++ b/pages/post/1.tsx
@@ -16,7 +16,7 @@ export default function index() {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <section className="text-gray-600 body-font">
-        <div className="container px-5 py-12 mx-auto">
+        <div className="container px-5 py-12  max-w-[64rem]  mx-auto">
           <GraduationCriteria />
           <div className="bg-gray-200 dark:bg-slate-700">
             <GPA />

--- a/pages/post/2.tsx
+++ b/pages/post/2.tsx
@@ -58,15 +58,19 @@ export default function index({ data }: any) {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <section className="text-gray-600 body-font ">
-        <div className="container px-5 py-12 mx-auto flex-col flexBox">
-          <div className="flex flex-wrap">{school}</div>
+        <div className="container px-5 py-12  max-w-[64rem]  mx-auto flex-col flexBox">
+          <div className="flexBox flex-wrap max-w-[64rem] mx-auto">
+            {school}
+          </div>
           <button className="flex-col flexBox" onClick={onClickMoreViewButton}>
             <p className="mb-4 font-base">
               {isSchoolMoreView ? '접기' : '더보기'}
             </p>
             {isSchoolMoreView ? <UpArrow /> : <DownArrow />}
           </button>
-          <div className="flex flex-wrap">{suburbs}</div>
+          <div className="flexBox flex-wrap max-w-[64rem] mx-auto">
+            {suburbs}
+          </div>
           <button
             className="flex-col flexBox"
             onClick={onClickSuburbsMoreViewButton}

--- a/pages/post/3.tsx
+++ b/pages/post/3.tsx
@@ -13,7 +13,7 @@ export default function index() {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <section className="text-gray-600 body-font">
-        <div className="container px-5 py-12 mx-auto flex flex-col">
+        <div className="container px-5 py-12 max-w-[64rem] mx-auto flex flex-col">
           <h1 className="text-6xl sm:text-5xl font-bold font-sans text-gray-900 mb-4 text-left">
             심리학과 메일 쓰기
           </h1>
@@ -61,7 +61,7 @@ export default function index() {
         </div>
       </section>
       <section className="text-gray-600 body-font bg-gray-200 dark:bg-slate-700">
-        <div className="container px-5 py-12 mx-auto flex flex-col">
+        <div className="container px-5 py-12 max-w-[64rem] mx-auto flex flex-col">
           <h2 className="font-bold text-2xl">메일 작성 CONCEPT : Simple</h2>
           <h3 className="text-base">
             메일은 간결하게, 본인의 신원과 메일의 목적을 명확하게 제시할 것.

--- a/pages/post/4.tsx
+++ b/pages/post/4.tsx
@@ -140,7 +140,9 @@ export default function index({ data }: any) {
                 label: '프로그램',
                 content: (
                   <div className="flexBox flex-col">
-                    <div className="flex-wrap flexBox">{lecture}</div>
+                    <div className="flex-wrap flexBox max-w-[64rem]">
+                      {lecture}
+                    </div>
                     <button
                       className="flex-col flexBox"
                       onClick={onClickMoreViewButton}
@@ -150,7 +152,9 @@ export default function index({ data }: any) {
                       </p>
                       {isLectureMoreView ? <UpArrow /> : <DownArrow />}
                     </button>
-                    <div className="flex-wrap flexBox">{seminar}</div>
+                    <div className="flex-wrap flexBox max-w-[64rem]">
+                      {seminar}
+                    </div>
                     <button
                       className="flex-col flexBox"
                       onClick={onClickSeminarMoreViewButton}
@@ -160,7 +164,9 @@ export default function index({ data }: any) {
                       </p>
                       {isSeminarMoreView ? <UpArrow /> : <DownArrow />}
                     </button>
-                    <div className="flex-wrap flexBox">{camp}</div>
+                    <div className="flex-wrap flexBox max-w-[64rem]">
+                      {camp}
+                    </div>
                   </div>
                 ),
               },
@@ -168,7 +174,7 @@ export default function index({ data }: any) {
                 id: '1',
                 label: '비교과 후기',
                 content: (
-                  <div className="text-gray-600 body-font">
+                  <div className="text-gray-600 body-font max-w-[64rem] mx-auto">
                     <section className="bg-secondaryColor">
                       <div className="container px-5 py-16 mx-auto flex-col flexBox ">
                         <h1 className="text-xl font-semibold mb-8">

--- a/pages/post/5.tsx
+++ b/pages/post/5.tsx
@@ -24,7 +24,7 @@ export default function index({ data }: any) {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <div className="text-gray-600 body-font">
+      <div className="text-gray-600 body-font max-w-[64rem] mx-auto">
         <section>
           <div className="container py-12 mx-auto flex-col flexBox ">
             <h1 className="text-5xl font-bold font-sans text-gray-900 mb-4 text-left">

--- a/pages/post/6.tsx
+++ b/pages/post/6.tsx
@@ -25,41 +25,43 @@ export default function index({ data }: any) {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <section>
-        <div className="container py-12 px-5 mx-auto flex-col flexBox ">
-          <h1 className="text-5xl font-bold font-sans text-gray-900 mb-4 text-left">
-            심리학과에서 공부하기
-          </h1>
-        </div>
-      </section>
-      <section className="text-gray-600 body-font bg-secondaryColor">
-        <div className="container px-5 py-12 mx-auto flex-col flexBox ">
-          <h1 className="text-xl font-semibold mb-8">
-            수강신청 성공하는 꿀팁!🍯
-          </h1>
-          <div className="overflow-y-auto w-full h-96 flex flex-col flex-wrap items-center p-4 bg-fixed">
-            {Enrole}
+      <div className="max-w-[64rem] mx-auto">
+        <section>
+          <div className="container py-12 px-5 mx-auto flex-col flexBox ">
+            <h1 className="text-5xl font-bold font-sans text-gray-900 mb-4 text-left">
+              심리학과에서 공부하기
+            </h1>
           </div>
-        </div>
-      </section>
-      <section className="text-gray-600 body-font">
-        <div className="container px-5 py-12 mx-auto flex-col flexBox ">
-          <h1 className="text-xl font-semibold mb-8">학과 공부 꿀팁!🍯</h1>
-          <div className="overflow-y-auto w-full h-96 flex flex-col flex-wrap items-center p-4 bg-fixed">
-            {StudyTip}
+        </section>
+        <section className="text-gray-600 body-font bg-secondaryColor">
+          <div className="container px-5 py-12 mx-auto flex-col flexBox ">
+            <h1 className="text-xl font-semibold mb-8">
+              수강신청 성공하는 꿀팁!🍯
+            </h1>
+            <div className="overflow-y-auto w-full h-96 flex flex-col flex-wrap items-center p-4 bg-fixed">
+              {Enrole}
+            </div>
           </div>
-        </div>
-      </section>
-      <section className="text-gray-600 body-font bg-shadowColor">
-        <div className="container px-5 py-12 mx-auto flex-col flexBox ">
-          <h1 className="dark:text-slate-700 text-xl font-semibold mb-8">
-            논문 검색 꿀팁!🍯
-          </h1>
-          <div className="overflow-y-auto w-full h-96 flex flex-col flex-wrap items-center p-4 bg-fixed">
-            {SearchTip}
+        </section>
+        <section className="text-gray-600 body-font">
+          <div className="container px-5 py-12 mx-auto flex-col flexBox ">
+            <h1 className="text-xl font-semibold mb-8">학과 공부 꿀팁!🍯</h1>
+            <div className="overflow-y-auto w-full h-96 flex flex-col flex-wrap items-center p-4 bg-fixed">
+              {StudyTip}
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
+        <section className="text-gray-600 body-font bg-shadowColor">
+          <div className="container px-5 py-12 mx-auto flex-col flexBox ">
+            <h1 className="dark:text-slate-700 text-xl font-semibold mb-8">
+              논문 검색 꿀팁!🍯
+            </h1>
+            <div className="overflow-y-auto w-full h-96 flex flex-col flex-wrap items-center p-4 bg-fixed">
+              {SearchTip}
+            </div>
+          </div>
+        </section>
+      </div>
     </Layout>
   );
 }

--- a/pages/post/7.tsx
+++ b/pages/post/7.tsx
@@ -24,7 +24,7 @@ export default function index({ data }: any) {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <div className="text-gray-600 body-font">
+      <div className="text-gray-600 body-font max-w-[64rem] mx-auto">
         <section>
           <div className="container py-12 px-5 mx-auto flex-col flexBox ">
             <h1 className="text-5xl font-bold font-sans text-gray-900 mb-4 text-left">

--- a/pages/post/8.tsx
+++ b/pages/post/8.tsx
@@ -16,7 +16,7 @@ export default function index({ data }: any) {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <div className="text-gray-600 body-font">
+      <div className="text-gray-600 body-font max-w-[64rem] mx-auto">
         <section>
           <div className="container py-12 px-5 mx-auto flex-col flexBox ">
             <h1 className="text-5xl font-bold font-sans text-gray-900 mb-4 text-left">


### PR DESCRIPTION
## 구현 목록
Issue: #34  #102 

- max 사이즈 없이 커져서 노트북(125%) 배율에서 봤을 때는 납작해보인다는 피드백을 받았다.

### 시도1
- 각 컴포넌트에 max-width를 적용했다. (실패)
- map을 통해 돌기 때문에 작아진 사이즈대로 돌면서 기존에 정해놓았던 레이아웃이 깨졌다. => 설계를 잘해야겠다고 생각했다.
![Artboard 1](https://user-images.githubusercontent.com/100553086/217238174-dbc8262e-d163-434b-8a18-dee5cdb267df.png)

### 시도2
- 기존 컴포넌트들은 모바일, 태블릿, 데스크탑 반응형을 고려해서 w-1/2, w-1/4 등으로 되어있었다.
- 아 그러면 map을 돌린 배열을 감싸주는 태그에서 넓이를 제한하면 w-1/2, w-1/4는 부모 컴포넌트의 n%에 해당하니까 되지 않을까?! 정답!!

### 시도3
- 시도2에 대한 내용을 해결하려고 도전해보다가 #34 이슈도 해결할 수 있었다.
- 34번 이슈는 더보기 했을 때 1행에 들어가는 컴포넌트 수가 4개로 늘어나는 것이 문제였는데 최대 너비를 제한하고, w-1/3으로 하니 해결할 수 있었다.
- 처음부터 고려하지 못한 점은 아쉬웠지만, 반응형으로 디자인해둔 덕분에 수정에 큰 시간을 들이진 않았다.

## 시연 
100% 기준에서 깔끔하게 마진이 있는 채로 나온다
![image](https://user-images.githubusercontent.com/100553086/217241855-c25b6115-a806-42d1-a3a0-9b6dc41b7fc9.png)


더보기는 이제 1줄에 3개씩 나온다
![image](https://user-images.githubusercontent.com/100553086/217241571-132fe96c-04ee-432c-84d9-2ea3d222e113.png)
