### PR TITLE
[🚑FIX] 취업 현황 배너를 수정한다

### DIFF
--- a/components/Career/InterviewWrapper.tsx
+++ b/components/Career/InterviewWrapper.tsx
@@ -11,7 +11,7 @@ export default function InterviewWrapper({
 }: CarrerProps) {
   return (
     <>
-      <div className="w-full md:w-1/3 lg:w-1/4 m-4">
+      <div className="w-1/2 md:w-1/3 lg:w-1/4 p-2">
         <div className="h-[285px] drop-shadow-xl dark:bg-slate-700 bg-gray-50 overflow-hidden relative">
           <Link href={`/carrer/$[tipId]`} as={`/career/${tipId}`}>
             <Image

--- a/pages/career/index.tsx
+++ b/pages/career/index.tsx
@@ -25,55 +25,57 @@ export default function Home({ CareerInterview }: any) {
           <meta name="viewport" content="width=device-width, initial-scale=1" />
           <link rel="icon" href="/favicon.ico" />
         </Head>
-        <section className="text-gray-600 body-font max-w-[64rem] mx-auto mb-36 flexBox">
-          <div className="container relative py-12">
-            {/* 취업 현황 배너 */}
-            <h1 className="text-5xl mb-4 font-medium">취업 현황</h1>
-            <Image
-              src={'/images/취업현황.webp'}
-              className="absolute w-full h-64 object-cover object-center"
-              alt="picture"
-              width={1024}
-              height={259}
-            />
-            <div className="absolute w-full flex-col flex justify-end items-center">
-              {/* 반투명한 검은 배경 */}
-              <div className="w-full h-64 bg-gray-900 opacity-50" />
-              {/* 흰색 취업 관련 정보 */}
-              <div className="absolute h-64 flex-col flex justify-end items-center p-8">
-                <h1 className="text-4xl font-bold mb-2.5 text-slate-100">
-                  취업 관련 정보
-                </h1>
-                <h2 className="text-base font-extralight text-slate-100 mb-6">
-                  심리학과 취업률, 급여, 취직 분야 통계 자료
-                </h2>
-                {/* 취업 정보 바로 가기 버튼 */}
-                <Link href="/career/info">
-                  <button
-                    className="w-40 h-9 border border-slate-100  flexBox
+        <section className="px-5">
+          <section className="text-gray-600 body-font max-w-[64rem] mx-auto mb-36 flexBox">
+            <div className="container relative py-12">
+              {/* 취업 현황 배너 */}
+              <h1 className="text-5xl mb-4 font-medium">취업 현황</h1>
+              <Image
+                src={'/images/취업현황.webp'}
+                className="absolute w-full h-64 object-cover object-center"
+                alt="picture"
+                width={1024}
+                height={259}
+              />
+              <div className="absolute w-full flex-col flex justify-end items-center">
+                {/* 반투명한 검은 배경 */}
+                <div className="w-full h-64 bg-gray-900 opacity-50" />
+                {/* 흰색 취업 관련 정보 */}
+                <div className="absolute h-64 flex-col flex justify-end items-center p-8">
+                  <h1 className="text-4xl font-bold mb-2.5 text-slate-100">
+                    취업 관련 정보
+                  </h1>
+                  <h2 className="text-base font-extralight text-slate-100 mb-6">
+                    심리학과 취업률, 급여, 취직 분야 통계 자료
+                  </h2>
+                  {/* 취업 정보 바로 가기 버튼 */}
+                  <Link href="/career/info">
+                    <button
+                      className="w-40 h-9 border border-slate-100  flexBox
                    hover:bg-slate-800 hover:scale-110 transition-transform ease-in-out duration-100"
-                  >
-                    <h2 className="px-5 text-base font-medium text-slate-100">
-                      취업 정보 바로가기
-                    </h2>
-                  </button>
-                </Link>
+                    >
+                      <h2 className="px-5 text-base font-medium text-slate-100">
+                        취업 정보 바로가기
+                      </h2>
+                    </button>
+                  </Link>
+                </div>
               </div>
             </div>
-          </div>
-        </section>
-        <section className="text-gray-600 body-font">
-          <div className="container relative py-12 max-w-[64rem] mx-auto ">
-            {/* 취업 인터뷰 */}
-            <div className="container py-12 mx-auto relative">
-              <h1 className="text-5xl mb-4 font-medium">취업 인터뷰</h1>
-              <p className="mb-8 text-base font-extralight text-gray-500">
-                심리학과 졸업생들의 취업 이야기. 취업과 관련된 다양한 궁금증을
-                물어봤습니다.
-              </p>
-              <div className="flex flex-wrap -m-4">{CarrerList}</div>
+          </section>
+          <section className="text-gray-600 body-font">
+            <div className="container relative py-12 max-w-[64rem] mx-auto ">
+              {/* 취업 인터뷰 */}
+              <div className="container py-12 mx-auto relative">
+                <h1 className="text-5xl mb-4 font-medium">취업 인터뷰</h1>
+                <p className="mb-8 text-base font-extralight text-gray-500">
+                  심리학과 졸업생들의 취업 이야기. 취업과 관련된 다양한 궁금증을
+                  물어봤습니다.
+                </p>
+                <div className="flex flex-wrap -m-4">{CarrerList}</div>
+              </div>
             </div>
-          </div>
+          </section>
         </section>
       </Layout>
     </>

--- a/pages/career/index.tsx
+++ b/pages/career/index.tsx
@@ -25,62 +25,54 @@ export default function Home({ CareerInterview }: any) {
           <meta name="viewport" content="width=device-width, initial-scale=1" />
           <link rel="icon" href="/favicon.ico" />
         </Head>
-
-        <section className="text-gray-600 body-font max-w-[64rem] mx-auto">
-          {/* 상단 배너 */}
-          <Image
-            src={'/images/취업.webp'}
-            className="h-48 w-full object-cover object-center mb-4"
-            alt="picture"
-            width={1920}
-            height={200}
-            priority={true}
-          />
-          <div className="container py-24 mx-auto relative">
-            <div className="mb-36">
-              {/* 취업 현황 배너 */}
-              <h1 className="text-5xl mb-4 font-medium">취업 현황</h1>
-              <Image
-                src={'/images/취업현황.webp'}
-                className="absolute w-full h-64 object-cover object-center"
-                alt="picture"
-                width={1024}
-                height={259}
-              />
-              <div className="absolute w-full flex-col flex justify-end items-center">
-                {/* 반투명한 검은 배경 */}
-                <div className="w-full h-64 bg-gray-900 opacity-50" />
-                {/* 흰색 취업 관련 정보 */}
-                <div className="absolute h-64 flex-col flex justify-end items-center p-8">
-                  <h1 className="text-4xl font-bold mb-2.5 text-slate-100">
-                    취업 관련 정보
-                  </h1>
-                  <h2 className="text-base font-extralight text-slate-100 mb-6">
-                    심리학과 취업률, 급여, 취직 분야 통계 자료
-                  </h2>
-                  {/* 취업 정보 바로 가기 버튼 */}
-                  <Link href="/career/info">
-                    <button
-                      className="w-40 h-9 border border-slate-100  flexBox
+        <section className="text-gray-600 body-font max-w-[64rem] mx-auto mb-36 flexBox">
+          <div className="container relative py-12">
+            {/* 취업 현황 배너 */}
+            <h1 className="text-5xl mb-4 font-medium">취업 현황</h1>
+            <Image
+              src={'/images/취업현황.webp'}
+              className="absolute w-full h-64 object-cover object-center"
+              alt="picture"
+              width={1024}
+              height={259}
+            />
+            <div className="absolute w-full flex-col flex justify-end items-center">
+              {/* 반투명한 검은 배경 */}
+              <div className="w-full h-64 bg-gray-900 opacity-50" />
+              {/* 흰색 취업 관련 정보 */}
+              <div className="absolute h-64 flex-col flex justify-end items-center p-8">
+                <h1 className="text-4xl font-bold mb-2.5 text-slate-100">
+                  취업 관련 정보
+                </h1>
+                <h2 className="text-base font-extralight text-slate-100 mb-6">
+                  심리학과 취업률, 급여, 취직 분야 통계 자료
+                </h2>
+                {/* 취업 정보 바로 가기 버튼 */}
+                <Link href="/career/info">
+                  <button
+                    className="w-40 h-9 border border-slate-100  flexBox
                    hover:bg-slate-800 hover:scale-110 transition-transform ease-in-out duration-100"
-                    >
-                      <h2 className="px-5 text-base font-medium text-slate-100">
-                        취업 정보 바로가기
-                      </h2>
-                    </button>
-                  </Link>
-                </div>
+                  >
+                    <h2 className="px-5 text-base font-medium text-slate-100">
+                      취업 정보 바로가기
+                    </h2>
+                  </button>
+                </Link>
               </div>
             </div>
           </div>
-          {/* 취업 인터뷰 */}
-          <div className="container px-5 py-12 mx-auto relative">
-            <h1 className="text-5xl mb-4 font-medium">취업 인터뷰</h1>
-            <p className="mb-8 text-base font-extralight text-gray-500">
-              심리학과 졸업생들의 취업 이야기. 취업과 관련된 다양한 궁금증을
-              물어봤습니다.
-            </p>
-            <div className="flex flex-wrap -m-4">{CarrerList}</div>
+        </section>
+        <section className="text-gray-600 body-font">
+          <div className="container relative py-12 max-w-[64rem] mx-auto ">
+            {/* 취업 인터뷰 */}
+            <div className="container py-12 mx-auto relative">
+              <h1 className="text-5xl mb-4 font-medium">취업 인터뷰</h1>
+              <p className="mb-8 text-base font-extralight text-gray-500">
+                심리학과 졸업생들의 취업 이야기. 취업과 관련된 다양한 궁금증을
+                물어봤습니다.
+              </p>
+              <div className="flex flex-wrap -m-4">{CarrerList}</div>
+            </div>
           </div>
         </section>
       </Layout>

--- a/pages/career/index.tsx
+++ b/pages/career/index.tsx
@@ -36,17 +36,16 @@ export default function Home({ CareerInterview }: any) {
             height={200}
             priority={true}
           />
-          <div className="container px-5 py-24 mx-auto relative">
-            <div className="w-2/3 max-w-5xl mb-36">
+          <div className="container py-24 mx-auto relative">
+            <div className="mb-36">
               {/* 취업 현황 배너 */}
               <h1 className="text-5xl mb-4 font-medium">취업 현황</h1>
               <Image
                 src={'/images/취업현황.webp'}
-                className="absolute w-full h-64 object-cover object-center mb-4"
+                className="absolute w-full h-64 object-cover object-center"
                 alt="picture"
-                width={1920}
-                height={200}
-                layout="fixed"
+                width={1024}
+                height={259}
               />
               <div className="absolute w-full flex-col flex justify-end items-center">
                 {/* 반투명한 검은 배경 */}


### PR DESCRIPTION
## 구현 목록
Issue: #84 

- [ ] 취업 현황 배너를 수정한다
- absolute 해놨던 Image들의 w-full을 받아오는 과정에서 문제가 있었고, px-5가 잘못 적용되고 있어, 분리했다.

## 시연 
![image](https://user-images.githubusercontent.com/100553086/217276385-b873470f-0fd7-4a3b-89f5-ea74a52ae700.png)
