### PR TITLE
[✨FEAT] 페이지 공유를 위해 주소를 수정한다

### DIFF
--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -20,7 +20,7 @@ export default function Header() {
               소개
             </Link>
             <Link
-              href="/graduate?id=1"
+              href="/graduate?category=1"
               className="mr-5 text-xl hover:text-gray-900"
             >
               대학원
@@ -28,7 +28,10 @@ export default function Header() {
             <Link href="/career" className="mr-5 text-xl hover:text-gray-900">
               취업
             </Link>
-            <Link href="/abroad" className="mr-5 text-xl hover:text-gray-900">
+            <Link
+              href="/abroad?category=1"
+              className="mr-5 text-xl hover:text-gray-900"
+            >
               유학
             </Link>
             {/* <Link href="/tool" className="mr-5 text-xl hover:text-gray-900">

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -19,7 +19,10 @@ export default function Header() {
             >
               소개
             </Link>
-            <Link href="/graduate" className="mr-5 text-xl hover:text-gray-900">
+            <Link
+              href="/graduate?id=1"
+              className="mr-5 text-xl hover:text-gray-900"
+            >
               대학원
             </Link>
             <Link href="/career" className="mr-5 text-xl hover:text-gray-900">

--- a/pages/abroad/index.tsx
+++ b/pages/abroad/index.tsx
@@ -32,37 +32,37 @@ const Tabs = ({ Bridge, Exchange, Multi, Short, Global, Advice }: any) => {
           <AbroadTab
             tabs={[
               {
-                id: '1',
+                id: 1,
                 label: '파란사다리',
                 banner: <Banner1 />,
                 content: <BridgePage Bridge={Bridge} />,
               },
               {
-                id: '2',
+                id: 2,
                 label: '교환학생',
                 banner: <Banner2 />,
                 content: <ExchangePage Exchange={Exchange} />,
               },
               {
-                id: '3',
+                id: 3,
                 label: '복수학위',
                 banner: <Banner3 />,
                 content: <MultiPage Multi={Multi} />,
               },
               {
-                id: '4',
+                id: 4,
                 label: '단기해외연수',
                 banner: <Banner4 />,
                 content: <ShortPage Short={Short} />,
               },
               {
-                id: '5',
+                id: 5,
                 label: '글로벌인턴쉽',
                 banner: <Banner5 />,
                 content: <GlobalPage Global={Global} />,
               },
               {
-                id: '6',
+                id: 6,
                 label: '선배님의 조언',
                 banner: <Banner6 />,
                 content: <AdvicePage Advice={Advice} />,

--- a/pages/abroad/index.tsx
+++ b/pages/abroad/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Head from 'next/head';
 import Layout from 'components/layout';
-import Tab from 'shared/components/Tab';
+import AbroadTab from 'shared/components/Tab/AbroadTab';
 import {
   Banner1,
   Banner2,
@@ -29,40 +29,40 @@ const Tabs = ({ Bridge, Exchange, Multi, Short, Global, Advice }: any) => {
       </Head>
       <section className="text-gray-600 body-font max-w-[64rem] mx-auto">
         <div className="container px-5 mx-auto">
-          <Tab
+          <AbroadTab
             tabs={[
               {
-                id: '0',
+                id: '1',
                 label: '파란사다리',
                 banner: <Banner1 />,
                 content: <BridgePage Bridge={Bridge} />,
               },
               {
-                id: '1',
+                id: '2',
                 label: '교환학생',
                 banner: <Banner2 />,
                 content: <ExchangePage Exchange={Exchange} />,
               },
               {
-                id: '2',
+                id: '3',
                 label: '복수학위',
                 banner: <Banner3 />,
                 content: <MultiPage Multi={Multi} />,
               },
               {
-                id: '3',
+                id: '4',
                 label: '단기해외연수',
                 banner: <Banner4 />,
                 content: <ShortPage Short={Short} />,
               },
               {
-                id: '4',
+                id: '5',
                 label: '글로벌인턴쉽',
                 banner: <Banner5 />,
                 content: <GlobalPage Global={Global} />,
               },
               {
-                id: '5',
+                id: '6',
                 label: '선배님의 조언',
                 banner: <Banner6 />,
                 content: <AdvicePage Advice={Advice} />,

--- a/pages/graduate/index.tsx
+++ b/pages/graduate/index.tsx
@@ -33,13 +33,13 @@ const Tabs = ({ Curriculum, Prepare, Life, Major, Free }: any) => {
           <GraduateTab
             tabs={[
               {
-                id: '1',
+                id: 1,
                 label: '추천 커리큘럼',
                 banner: <Banner1 />,
                 content: <CurriculumPage Curriculum={Curriculum} />,
               },
               {
-                id: '2',
+                id: 2,
                 label: '대학원 준비',
                 banner: <Banner2 />,
                 content: (
@@ -50,7 +50,7 @@ const Tabs = ({ Curriculum, Prepare, Life, Major, Free }: any) => {
                 ),
               },
               {
-                id: '3',
+                id: 3,
                 label: '대학원 생활',
                 banner: <Banner3 />,
                 content: (
@@ -61,7 +61,7 @@ const Tabs = ({ Curriculum, Prepare, Life, Major, Free }: any) => {
                 ),
               },
               {
-                id: '4',
+                id: 4,
                 label: '전공별 질문',
                 banner: <Banner4 />,
                 content: (
@@ -71,13 +71,13 @@ const Tabs = ({ Curriculum, Prepare, Life, Major, Free }: any) => {
                 ),
               },
               {
-                id: '5',
+                id: 5,
                 label: '자유발언',
                 banner: <Banner5 />,
                 content: <FreePage Free={Free} />,
               },
               {
-                id: '6',
+                id: 6,
                 label: '입시요강',
                 banner: <Banner6 />,
                 content: <GuidePage />,

--- a/pages/graduate/index.tsx
+++ b/pages/graduate/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Head from 'next/head';
 import Layout from 'components/layout';
-import Tab from 'shared/components/Tab';
+import GraduateTab from 'shared/components/Tab/GraduateTab';
 import {
   Banner1,
   Banner2,
@@ -30,16 +30,16 @@ const Tabs = ({ Curriculum, Prepare, Life, Major, Free }: any) => {
       </Head>
       <section className="text-gray-600 body-font max-w-[64rem] mx-auto">
         <div className="container px-5 mx-auto">
-          <Tab
+          <GraduateTab
             tabs={[
               {
-                id: '0',
+                id: '1',
                 label: '추천 커리큘럼',
                 banner: <Banner1 />,
                 content: <CurriculumPage Curriculum={Curriculum} />,
               },
               {
-                id: '1',
+                id: '2',
                 label: '대학원 준비',
                 banner: <Banner2 />,
                 content: (
@@ -50,7 +50,7 @@ const Tabs = ({ Curriculum, Prepare, Life, Major, Free }: any) => {
                 ),
               },
               {
-                id: '2',
+                id: '3',
                 label: '대학원 생활',
                 banner: <Banner3 />,
                 content: (
@@ -61,7 +61,7 @@ const Tabs = ({ Curriculum, Prepare, Life, Major, Free }: any) => {
                 ),
               },
               {
-                id: '3',
+                id: '4',
                 label: '전공별 질문',
                 banner: <Banner4 />,
                 content: (
@@ -71,13 +71,13 @@ const Tabs = ({ Curriculum, Prepare, Life, Major, Free }: any) => {
                 ),
               },
               {
-                id: '4',
+                id: '5',
                 label: '자유발언',
                 banner: <Banner5 />,
                 content: <FreePage Free={Free} />,
               },
               {
-                id: '5',
+                id: '6',
                 label: '입시요강',
                 banner: <Banner6 />,
                 content: <GuidePage />,

--- a/shared/components/Tab/AbroadTab.tsx
+++ b/shared/components/Tab/AbroadTab.tsx
@@ -1,9 +1,9 @@
 import { useRouter } from 'next/router';
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import { useState } from 'react';
 
 interface Tab {
-  id?: string;
+  id?: number;
   label?: string;
   banner?: React.ReactNode;
   content?: React.ReactNode;
@@ -15,7 +15,16 @@ interface Props {
 
 const AbroadTab: FC<Props> = ({ tabs }) => {
   const router = useRouter();
+  const { category } = router.query;
   const [activeTab, setActiveTab] = useState(tabs[0].id);
+
+  // 다른 사람이 카테고리 입력했을 때 해당하는 페이지를 보여주도록
+  useEffect(() => {
+    if (category) {
+      setActiveTab(+category);
+    }
+  }, [category]);
+
   const handleTabClick = (category: any) => {
     setActiveTab(category);
     router.push({
@@ -36,7 +45,7 @@ const AbroadTab: FC<Props> = ({ tabs }) => {
             // 선택된 탭이면 배경색 바뀌도록
             className={`py-px px-4 flexBox flex-wrap text-xl font-normal ${
               activeTab === tab.id ? 'text-secondaryColor' : ''
-            } ${tab.id === '5' ? '' : 'border-r'}`}
+            } ${tab.id === 6 ? '' : 'border-r'}`}
             onClick={() => handleTabClick(tab.id)}
           >
             {/* 탭 라벨 */}

--- a/shared/components/Tab/AbroadTab.tsx
+++ b/shared/components/Tab/AbroadTab.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router';
 import React, { FC } from 'react';
 import { useState } from 'react';
 
@@ -13,10 +14,14 @@ interface Props {
 }
 
 const AbroadTab: FC<Props> = ({ tabs }) => {
+  const router = useRouter();
   const [activeTab, setActiveTab] = useState(tabs[0].id);
-  const handleTabClick = (tabId: any) => {
-    setActiveTab(tabId);
-    window.history.pushState({}, '', `/abroad/${tabId}`);
+  const handleTabClick = (category: any) => {
+    setActiveTab(category);
+    router.push({
+      pathname: '/abroad',
+      query: { category },
+    });
   };
 
   return (

--- a/shared/components/Tab/AbroadTab.tsx
+++ b/shared/components/Tab/AbroadTab.tsx
@@ -12,8 +12,12 @@ interface Props {
   tabs: Tab[];
 }
 
-const Tab: FC<Props> = ({ tabs }) => {
+const AbroadTab: FC<Props> = ({ tabs }) => {
   const [activeTab, setActiveTab] = useState(tabs[0].id);
+  const handleTabClick = (tabId: any) => {
+    setActiveTab(tabId);
+    window.history.pushState({}, '', `/abroad/${tabId}`);
+  };
 
   return (
     <>
@@ -28,7 +32,7 @@ const Tab: FC<Props> = ({ tabs }) => {
             className={`py-px px-4 flexBox flex-wrap text-xl font-normal ${
               activeTab === tab.id ? 'text-secondaryColor' : ''
             } ${tab.id === '5' ? '' : 'border-r'}`}
-            onClick={() => setActiveTab(tab.id)}
+            onClick={() => handleTabClick(tab.id)}
           >
             {/* 탭 라벨 */}
             {tab.label}
@@ -43,4 +47,4 @@ const Tab: FC<Props> = ({ tabs }) => {
   );
 };
 
-export default Tab;
+export default AbroadTab;

--- a/shared/components/Tab/GraduateTab.tsx
+++ b/shared/components/Tab/GraduateTab.tsx
@@ -16,11 +16,11 @@ interface Props {
 const GraduateTab: FC<Props> = ({ tabs }) => {
   const router = useRouter();
   const [activeTab, setActiveTab] = useState(tabs[0].id);
-  const handleTabClick = (id: any) => {
-    setActiveTab(id);
+  const handleTabClick = (category: any) => {
+    setActiveTab(category);
     router.push({
       pathname: '/graduate',
-      query: { id },
+      query: { category },
     });
   };
 

--- a/shared/components/Tab/GraduateTab.tsx
+++ b/shared/components/Tab/GraduateTab.tsx
@@ -1,0 +1,50 @@
+import React, { FC } from 'react';
+import { useState } from 'react';
+
+interface Tab {
+  id?: string;
+  label?: string;
+  banner?: React.ReactNode;
+  content?: React.ReactNode;
+}
+
+interface Props {
+  tabs: Tab[];
+}
+
+const GraduateTab: FC<Props> = ({ tabs }) => {
+  const [activeTab, setActiveTab] = useState(tabs[0].id);
+  const handleTabClick = (tabId: any) => {
+    setActiveTab(tabId);
+    window.history.pushState({}, '', `/graduate/${tabId}`);
+  };
+
+  return (
+    <>
+      {/* 배너 */}
+      {tabs.find((tab) => tab.id === activeTab)?.banner}
+      {/* 탭 나열 */}
+      <ul className="flexBox flex-wrap flex-shrink-0 border-gray-200">
+        {tabs.map((tab) => (
+          <li
+            key={tab.id}
+            // 선택된 탭이면 배경색 바뀌도록
+            className={`py-px px-4 flexBox flex-wrap text-xl font-normal ${
+              activeTab === tab.id ? 'text-secondaryColor' : ''
+            } ${tab.id === '5' ? '' : 'border-r'}`}
+            onClick={() => handleTabClick(tab.id)}
+          >
+            {/* 탭 라벨 */}
+            {tab.label}
+          </li>
+        ))}
+      </ul>
+      <div className="p-6">
+        {/* 여기에 내용 삽입 */}
+        {tabs.find((tab) => tab.id === activeTab)?.content}
+      </div>
+    </>
+  );
+};
+
+export default GraduateTab;

--- a/shared/components/Tab/GraduateTab.tsx
+++ b/shared/components/Tab/GraduateTab.tsx
@@ -1,3 +1,4 @@
+import { Router, useRouter } from 'next/router';
 import React, { FC } from 'react';
 import { useState } from 'react';
 
@@ -13,10 +14,14 @@ interface Props {
 }
 
 const GraduateTab: FC<Props> = ({ tabs }) => {
+  const router = useRouter();
   const [activeTab, setActiveTab] = useState(tabs[0].id);
-  const handleTabClick = (tabId: any) => {
-    setActiveTab(tabId);
-    window.history.pushState({}, '', `/graduate/${tabId}`);
+  const handleTabClick = (id: any) => {
+    setActiveTab(id);
+    router.push({
+      pathname: '/graduate',
+      query: { id },
+    });
   };
 
   return (

--- a/shared/components/Tab/GraduateTab.tsx
+++ b/shared/components/Tab/GraduateTab.tsx
@@ -36,7 +36,7 @@ const GraduateTab: FC<Props> = ({ tabs }) => {
             // 선택된 탭이면 배경색 바뀌도록
             className={`py-px px-4 flexBox flex-wrap text-xl font-normal ${
               activeTab === tab.id ? 'text-secondaryColor' : ''
-            } ${tab.id === 5 ? '' : 'border-r'}`}
+            } ${tab.id === 6 ? '' : 'border-r'}`}
             onClick={() => handleTabClick(tab.id)}
           >
             {/* 탭 라벨 */}

--- a/shared/components/Tab/GraduateTab.tsx
+++ b/shared/components/Tab/GraduateTab.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 import { useState } from 'react';
 
 interface Tab {
-  id?: string;
+  id?: number;
   label?: string;
   banner?: React.ReactNode;
   content?: React.ReactNode;
@@ -31,7 +31,7 @@ const GraduateTab: FC<Props> = ({ tabs }) => {
             // 선택된 탭이면 배경색 바뀌도록
             className={`py-px px-4 flexBox flex-wrap text-xl font-normal ${
               activeTab === tab.id ? 'text-secondaryColor' : ''
-            } ${tab.id === '5' ? '' : 'border-r'}`}
+            } ${tab.id === 5 ? '' : 'border-r'}`}
             onClick={() => handleTabClick(tab.id)}
           >
             {/* 탭 라벨 */}

--- a/shared/components/Tab/GraduateTab.tsx
+++ b/shared/components/Tab/GraduateTab.tsx
@@ -1,5 +1,5 @@
-import { Router, useRouter } from 'next/router';
-import React, { FC } from 'react';
+import { useRouter } from 'next/router';
+import React, { FC, useEffect } from 'react';
 import { useState } from 'react';
 
 interface Tab {
@@ -15,7 +15,16 @@ interface Props {
 
 const GraduateTab: FC<Props> = ({ tabs }) => {
   const router = useRouter();
+  const { category } = router.query;
   const [activeTab, setActiveTab] = useState(tabs[0].id);
+
+  // 다른 사람이 카테고리 입력했을 때 해당하는 페이지를 보여주도록
+  useEffect(() => {
+    if (category) {
+      setActiveTab(+category);
+    }
+  }, [category]);
+
   const handleTabClick = (category: any) => {
     setActiveTab(category);
     router.push({


### PR DESCRIPTION
## 구현 목록
Issue: #114 

- [ ] 인덱스를 0-5에서 1-6으로 변경한다
- [ ] 페이지뷰 추적을 위해 각 탭을 클릭했을 때, 쿼리가 변경되도록 한다
- [ ] 쿼리를 공유했을 때, 그 쿼리 링크가 보여야 한다

### 변경 이유
- 구글 애널리틱스를 연동해서 페이지뷰를 확인할 수 있었다. 하지만 문제는 기존에 대학원과 유학을 탭 선택시 스타일을 변경한 채로 콘텐츠를 보여주기 위해서, `/graduate`와 `/abroad`에 탭 방식으로 놓은 것이었다. 대학원, 유학 이하의 탭에서 어떻게 반응하고, 개선해야 할지 정보를 얻고 싶었는데, 거기까지 페이지뷰 측정이 되지 않아 어려웠다.
![image](https://user-images.githubusercontent.com/100553086/217514500-c2bd1b5d-2191-48af-928f-2a9e084c1f2f.png)

### 1차 시도
- pages로 변경할까도 고민했지만, 통계를 위해 페이지를 변경하는 건 비효율적이라고 생각했다. 
- window.history.push를 통해서 탭을 클릭했을 때, 임시적으로 변경되도록 했다.
- 문제는 이 링크를 공유해서 접근했을 때 404 페이지가 뜬다는 것입니다. 실제 주소가 아니라 링크만 추가한 것이라서..!

### 2차 시도
- 쿼리를 이용해서 페이지를 기록하고 변경하는 것이다.
![image](https://user-images.githubusercontent.com/100553086/217514922-9b4180c7-371a-4a47-b83e-968e86b3eeb3.png)

### 3차 시도
- Merge 안 해도 프리뷰로 vercel 어떻게 나오는지 확인할 수 있다는 걸 최근에 알게 되었다. 프리뷰로 확인하고 링크 공유했을 때 404는 안 뜨는데 주소는 category=4 지만, 해당하는 내용이 뜨지 않았다.
- 휘유 useEffect를 통해서 카테고리가 바뀌었을 때 탭이 변경되도록 했다! 해결 완료!

```
  // 다른 사람이 카테고리 입력했을 때 해당하는 페이지를 보여주도록
  useEffect(() => {
    if (category) {
      setActiveTab(+category);
    }
  }, [category]);
```

## 시연 
![image](https://user-images.githubusercontent.com/100553086/217512893-ba35dd09-f33d-47be-9e4b-7257a70e1cc5.png)
