### PR TITLE
[✨FEAT] 자유발언 페이지에 반응형을 적용한다

### DIFF
--- a/components/Graduate/FreeCard.tsx
+++ b/components/Graduate/FreeCard.tsx
@@ -3,7 +3,7 @@ import { EnrolementProps } from 'shared/store/type';
 export default function FreeCard({ idx, name, tip }: EnrolementProps) {
   return (
     <div
-      className={`col-span-1 h-full p-4 ${idx! % 3 === 2 ? '' : 'border-r'}`}
+      className={`col-span-1 h-full p-4 ${idx! % 3 === 2 ? '' : 'sm:border-r'}`}
     >
       <p className="text-base font-extralight">{tip}</p>
       <p className="text-base font-bold mt-1">{name}</p>

--- a/components/Graduate/content/free.tsx
+++ b/components/Graduate/content/free.tsx
@@ -7,7 +7,9 @@ const FreePage = ({ Free }: any) => {
     return <FreeCard key={idx} idx={idx} name={el.name} tip={el.tip} />;
   });
 
-  return <div className="grid grid-cols-3 gap-4">{FreeList}</div>;
+  return (
+    <div className="grid gird-cols-1 sm:grid-cols-3 gap-4">{FreeList}</div>
+  );
 };
 
 export default FreePage;


### PR DESCRIPTION
## 구현 목록
Issue: #116 

- [ ] 모바일 버전에서 border 삭제
- [ ] 모바일 버전에서 1열로 수정

- 어렵게 느꼈는데, flex와 grid를 공부하니 생각보다 답이 쉽게 보였다

## 시연
모바일에서 1열로 보이고 border 삭제

|![image](https://user-images.githubusercontent.com/100553086/217739216-ecbec630-feea-4fbd-9b11-f0dbd09d4924.png)|![image](https://user-images.githubusercontent.com/100553086/217739294-8a81cb9b-e6c0-45e3-bb1d-4adefca93c74.png)|
|---|---|

 