### PR TITLE
 [📝DATA] 전공선택으로 표기를 수정한다

### DIFF
--- a/data/Career/Analyst.json
+++ b/data/Career/Analyst.json
@@ -83,7 +83,9 @@
               "name": "사회심리학 및 실험",
               "engName": "Theories & Experiments in Social Psychology",
               "explain": "사회적 상황에서의 인간의 행동과 사고과정에 관한 여러 이 론들과 실험연구들을 고찰한다."
-            },
+            }
+          ],
+          "majorChoice": [
             {
               "name": "데이터 분석 방법과 적용",
               "engName": "Data Analysis and Its Application",


### PR DESCRIPTION
## 구현 목록
Issue: #143 

- [ ] 데이터 분석 방법과 적용의 표기를 전공선택으로 수정하였다.

## 시연 
|![image](https://user-images.githubusercontent.com/100553086/222950427-ac1e54d4-56cb-4601-8574-259ee340a4c6.png)|![image](https://user-images.githubusercontent.com/100553086/222950442-e35bf5c3-ed1e-4731-9ec3-595da3b0ec8e.png)|
|---|---|

